### PR TITLE
Refactor imports and enhance Base64 decoding error handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use log::{error, info};
 use std::fs;
 
 use subconverter::settings::settings::settings_struct::init_settings;
-use subconverter::{api, web_handlers, Settings};
+use subconverter::{web_handlers, Settings};
 
 /// A more powerful utility to convert between proxy subscription format
 #[derive(Parser, Debug)]

--- a/src/template/template_renderer.rs
+++ b/src/template/template_renderer.rs
@@ -25,15 +25,6 @@ pub struct TemplateArgs {
     pub node_list: HashMap<String, String>,
 }
 
-/// Context for template rendering
-#[derive(Debug, Serialize)]
-struct TemplateContext {
-    global: HashMap<String, String>,
-    request: HashMap<String, String>,
-    local: HashMap<String, String>,
-    node_list: HashMap<String, String>,
-}
-
 /// Render a template with the given arguments
 ///
 /// # Arguments

--- a/src/utils/http_std.rs
+++ b/src/utils/http_std.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::error::Error as StdError;
 use std::time::Duration;
 
-use reqwest::{Client, Proxy, StatusCode};
+use reqwest::{Client, Proxy};
 
 /// Default timeout for HTTP requests in seconds
 const DEFAULT_TIMEOUT: u64 = 15;


### PR DESCRIPTION
- Removed unused import of `api` from `subconverter` in `main.rs` for cleaner code.
- Deleted the `TemplateContext` struct in `template_renderer.rs` to simplify the template rendering context.
- Improved Base64 decoding in `base64.rs` by adding a more flexible padding mode and logging errors during decoding.
- Streamlined the `url_safe_base64_apply` function for better readability.
- Cleaned up unused import in `http_std.rs` to maintain code clarity.