### PR TITLE
Remove RUSTFLAGS from build steps in GitHub Actions workflows

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -59,8 +59,6 @@ jobs:
 
     - name: Build with cross
       run: cross build --release --features=web-api --target ${{ matrix.target }}
-      env:
-        RUSTFLAGS: "-C target-feature=+crt-static"
 
     - name: Prepare artifact
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,6 @@ jobs:
       
     - name: Build with cross
       run: cross build --release --features=web-api --target ${{ matrix.target }}
-      env:
-        RUSTFLAGS: "-C target-feature=+crt-static"
         
     - name: Prepare artifact
       run: |


### PR DESCRIPTION
- Eliminated the RUSTFLAGS environment variable from the build steps in both `dev-build.yml` and `release.yml`.
- This change simplifies the build configuration and may improve compatibility across different environments.