### PR TITLE
Changed the target for the `armv7` and `aarch64` architectures in both `dev-build.yml` and `release.yml` to use `musl` instead of `gnu`, enhancing compatibility for static linking.

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -59,6 +59,8 @@ jobs:
 
     - name: Build with cross
       run: cross build --release --features=web-api --target ${{ matrix.target }}
+      env:
+        RUSTFLAGS: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' && '-C target-feature=+crt-static' || '' }}
 
     - name: Prepare artifact
       run: |

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -26,11 +26,11 @@ jobs:
           - arch: armv7
             artifact: subconverter-linux-armv7
             os: ubuntu-latest
-            target: armv7-unknown-linux-gnueabihf
+            target: armv7-unknown-linux-musleabihf
           - arch: aarch64
             artifact: subconverter-linux-aarch64
             os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
     runs-on: ${{ matrix.os }}
     name: Linux ${{ matrix.arch }} Dev Build
     steps:
@@ -59,8 +59,6 @@ jobs:
 
     - name: Build with cross
       run: cross build --release --features=web-api --target ${{ matrix.target }}
-      env:
-        RUSTFLAGS: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' && '-C target-feature=+crt-static' || '' }}
 
     - name: Prepare artifact
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,7 @@ jobs:
       
     - name: Build with cross
       run: cross build --release --features=web-api --target ${{ matrix.target }}
-      env:
-        RUSTFLAGS: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' && '-C target-feature=+crt-static' || '' }}
-        
+      
     - name: Prepare artifact
       run: |
         mkdir -p subconverter/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,8 @@ jobs:
       
     - name: Build with cross
       run: cross build --release --features=web-api --target ${{ matrix.target }}
+      env:
+        RUSTFLAGS: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' && '-C target-feature=+crt-static' || '' }}
         
     - name: Prepare artifact
       run: |


### PR DESCRIPTION
- Changed the target for the `armv7` and `aarch64` architectures in both `dev-build.yml` and `release.yml` to use `musl` instead of `gnu`, enhancing compatibility for static linking.

- Removed the RUSTFLAGS environment variable from the build steps to simplify the configuration.