### PR TITLE
Add support for loongarch64 and riscv64 architectures in release.yml 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,14 @@ jobs:
             artifact: subconverter-linux-aarch64
             os: ubuntu-latest
             target: aarch64-unknown-linux-musl
+          - arch: loongarch64
+            artifact: subconverter-linux-loongarch64
+            os: ubuntu-latest
+            target: loongarch64-unknown-linux-musl
+          - arch: riscv64
+            artifact: subconverter-linux-riscv64
+            os: ubuntu-latest
+            target: riscv64gc-unknown-linux-musl
     runs-on: ${{ matrix.os }}
     name: Linux ${{ matrix.arch }} Build
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,11 @@ jobs:
           - arch: armv7
             artifact: subconverter-linux-armv7
             os: ubuntu-latest
-            target: armv7-unknown-linux-gnueabihf
+            target: armv7-unknown-linux-musleabihf
           - arch: aarch64
             artifact: subconverter-linux-aarch64
             os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
     runs-on: ${{ matrix.os }}
     name: Linux ${{ matrix.arch }} Build
     steps:


### PR DESCRIPTION
- Introduced new target specifications for `loongarch64` and `riscv64` architectures in the GitHub Actions workflow.
- This enhancement expands the build capabilities to include additional architectures, improving compatibility across diverse Linux environments.