### PR TITLE
Add request headers support in Subconverter

### DIFF
--- a/src/api/sub.rs
+++ b/src/api/sub.rs
@@ -105,6 +105,9 @@ pub struct SubconverterQuery {
     /// Singbox specific parameters
     #[serde(default)]
     pub singbox: HashMap<String, String>,
+
+    /// Request headers
+    pub request_headers: Option<HashMap<String, String>>,
 }
 
 /// Parse a query string into a HashMap
@@ -469,8 +472,12 @@ pub async fn sub_process(
 
     // // Set managed config prefix from global settings
     // if !global.managed_config_prefix.is_empty() {
-    //     builder = builder.managed_config_prefix(global.managed_config_prefix.clone());
-    // }
+    //     builder =
+    // builder.managed_config_prefix(global.managed_config_prefix.clone()); }
+
+    if let Some(request_headers) = &query.request_headers {
+        builder.request_headers(request_headers.clone());
+    }
 
     // Build and validate configuration
     let config = match builder.build() {

--- a/www/src/app/api/sub/route.ts
+++ b/www/src/app/api/sub/route.ts
@@ -21,7 +21,9 @@ export async function GET(request: NextRequest) {
     }
 
     // Construct a JSON query object from URL parameters
-    const params = Object.fromEntries(request.nextUrl.searchParams);
+    const params: any = Object.fromEntries(request.nextUrl.searchParams);
+    const requestHeaders = Object.fromEntries(request.headers.entries());
+    params['request_headers'] = requestHeaders;
 
     // Normalize the 'url' parameter if it exists
     if (typeof params.url === 'string') {


### PR DESCRIPTION
- Introduced a new `request_headers` field in `SubconverterQuery` and `SubconverterConfig` to allow passing custom headers.
- Updated the `sub_handler` to extract headers from the incoming request and include them in the processing.
- Modified the `parse_subscription` function to handle the new request headers, ensuring they are passed along during subscription parsing.
- Enhanced the overall flexibility of the Subconverter by allowing users to specify headers for their requests.