### PR TITLE
Add Gist upload functionality and update dependencies 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1829,7 +1829,19 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,13 @@ console_log = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 awc = { version = "3.6.0", features = ["rustls"] }
-tokio = { version = "1.43.0", features = ["rt", "fs", "sync", "io-util"] }
+tokio = { version = "1.43.0", features = [
+    "rt",
+    "fs",
+    "sync",
+    "io-util",
+    "macros",
+] }
 
 [dev-dependencies]
 tempfile = "3.10.1"

--- a/base/gistconf.ini
+++ b/base/gistconf.ini
@@ -1,3 +1,4 @@
 [common]
 ;uncomment the following line and enter your token to enable upload function
 ;token = your_personal_token_here
+;username = your_github_username_here

--- a/examples/upload_gist_example.rs
+++ b/examples/upload_gist_example.rs
@@ -1,0 +1,228 @@
+use awc::Client;
+use case_insensitive_string::CaseInsensitiveString;
+use libsubconverter::upload::gist::upload_gist;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::time::Duration;
+
+const DUMMY_INI_PATH: &str = "./gistconf.ini"; // Relative to where example is run (project root)
+
+/// Fetches the ID and owner login of the first Gist found for the authenticated
+/// user.
+async fn fetch_first_gist_details(token: &str) -> Option<(String, String)> {
+    log::info!("Attempting to fetch existing Gist details using provided token...");
+    let client = Client::builder().timeout(Duration::from_secs(10)).finish();
+    let url = "https://api.github.com/gists";
+
+    let mut headers = HashMap::new();
+    headers.insert(
+        CaseInsensitiveString::new("Authorization"),
+        format!("token {}", token),
+    );
+    headers.insert(
+        CaseInsensitiveString::new("Accept"),
+        "application/vnd.github.v3+json".to_string(),
+    );
+    headers.insert(
+        CaseInsensitiveString::new("User-Agent"),
+        "subconverter-rs-example".to_string(),
+    );
+
+    let mut client_request = client.get(url);
+    for (key, value) in &headers {
+        client_request = client_request.insert_header((key.as_ref(), value.as_str()));
+    }
+
+    match client_request.send().await {
+        Ok(mut response) => {
+            let status = response.status();
+            if status.is_success() {
+                match response.json::<Value>().await {
+                    Ok(gists) => {
+                        if let Some(first_gist) = gists.as_array().and_then(|arr| arr.get(0)) {
+                            if let (Some(id), Some(login)) = (
+                                first_gist["id"].as_str(),
+                                first_gist["owner"]["login"].as_str(),
+                            ) {
+                                log::info!("Found existing Gist: ID={}, Owner={}", id, login);
+                                Some((id.to_string(), login.to_string()))
+                            } else {
+                                log::warn!(
+                                    "First Gist found but missing 'id' or 'owner.login' fields."
+                                );
+                                None
+                            }
+                        } else {
+                            log::warn!("No Gists found for the provided token.");
+                            None
+                        }
+                    }
+                    Err(e) => {
+                        log::error!("Failed to parse Gist list response JSON: {}", e);
+                        None
+                    }
+                }
+            } else {
+                let body = response
+                    .body()
+                    .await
+                    .map(|b| String::from_utf8_lossy(&b).to_string())
+                    .unwrap_or_else(|_| "<failed to read body>".to_string());
+                log::error!(
+                    "Failed to fetch Gist list: Status {}, Body: {}",
+                    status,
+                    body
+                );
+                None
+            }
+        }
+        Err(e) => {
+            log::error!("HTTP request to fetch Gist list failed: {}", e);
+            None
+        }
+    }
+}
+
+async fn setup_dummy_ini(token: Option<&str>, id: Option<&str>, username: Option<&str>) {
+    let mut content = "[common]\n".to_string();
+    if let Some(t) = token {
+        content.push_str(&format!("token={}\n", t));
+    }
+    if let Some(i) = id {
+        content.push_str(&format!("id={}\n", i));
+    }
+    if let Some(u) = username {
+        content.push_str(&format!("username={}\n", u));
+    }
+
+    let mut file = fs::File::create(DUMMY_INI_PATH).expect("Failed to create dummy ini");
+    file.write_all(content.as_bytes())
+        .expect("Failed to write dummy ini");
+    println!(
+        "Created dummy {} with content:\n{}",
+        DUMMY_INI_PATH, content
+    );
+}
+
+fn cleanup_dummy_ini() {
+    match fs::remove_file(DUMMY_INI_PATH) {
+        Ok(_) => println!("Cleaned up dummy {}", DUMMY_INI_PATH),
+        Err(e) => println!("Failed to clean up dummy {}: {}", DUMMY_INI_PATH, e),
+    }
+}
+
+#[actix_web::main]
+async fn main() {
+    // Basic logging setup for the example
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    println!("--- Running upload_gist example ---");
+
+    // --- Attempt to fetch existing Gist details if token is available ---
+    let github_token = env::var("GITHUB_TOKEN").ok();
+    let existing_gist_details = if let Some(token) = github_token.as_deref() {
+        fetch_first_gist_details(token).await
+    } else {
+        log::warn!("GITHUB_TOKEN environment variable not set. Update tests will use dummy data or may fail.");
+        None
+    };
+
+    // --- Test Case 1: No INI file, relies on GITHUB_TOKEN env var (if set) ---
+    println!("\n--- Test Case 1: No INI file ---");
+    // Ensure no dummy file exists for this case
+    let _ = fs::remove_file(DUMMY_INI_PATH);
+    match upload_gist(
+        "MyConfigName",
+        "my_subconverter_config.txt".to_string(),
+        "This is the content for the new gist file.".to_string(),
+        false, // Don't write managed URL for new gist
+    )
+    .await
+    {
+        Ok(_) => println!("upload_gist (Test 1) succeeded."),
+        Err(e) => println!("upload_gist (Test 1) failed: {}", e),
+    }
+
+    // --- Test Case 2: INI file exists, but no token (relies on env var) ---
+    println!("\n--- Test Case 2: INI file without token ---");
+    // Use fetched details if available, otherwise use dummies
+    let (test2_id, test2_user) = existing_gist_details
+        .as_ref()
+        .map(|(id, user)| (id.as_str(), user.as_str()))
+        .unwrap_or(("some_dummy_gist_id", "some_dummy_username"));
+    log::info!(
+        "Using Gist ID: {}, Username: {} for Test 2",
+        test2_id,
+        test2_user
+    );
+    setup_dummy_ini(None, None, Some(test2_user)).await;
+    match upload_gist(
+        "AnotherConfig",
+        "another_config.yaml".to_string(),
+        "YAML content here".to_string(),
+        true, // Write managed URL when updating
+    )
+    .await
+    {
+        Ok(_) => println!("upload_gist (Test 2) succeeded."),
+        Err(e) => println!("upload_gist (Test 2) failed: {}", e),
+    }
+    cleanup_dummy_ini();
+
+    // --- Test Case 3: INI file with token ---
+    println!("\n--- Test Case 3: INI file with token ---");
+    setup_dummy_ini(github_token.as_deref(), None, None).await; // Create new gist
+    match upload_gist(
+        "IniTokenTest",
+        "test_from_ini.txt".to_string(),
+        "Content using token from INI file.".to_string(),
+        false,
+    )
+    .await
+    {
+        Ok(_) => println!("upload_gist (Test 3) succeeded."),
+        Err(e) => println!("upload_gist (Test 3) failed: {}", e),
+    }
+    // Note: Test 3 will likely fail if DUMMY_TOKEN_FROM_INI is not a valid token.
+    // It will also create/modify the dummy ini file.
+
+    // --- Test Case 4: INI file with token, id, and username (update) ---
+    println!("\n--- Test Case 4: INI file with token, id, username (update) ---");
+    // Re-use the INI potentially modified by Test 3, or create a new one
+    // Use fetched details if available, otherwise use dummies
+    let (test4_id, test4_user) = existing_gist_details
+        .as_ref()
+        .map(|(id, user)| (id.as_str(), user.as_str()))
+        .unwrap_or(("another_dummy_gist_id", "another_dummy_username"));
+    log::info!(
+        "Using Gist ID: {}, Username: {} for Test 4",
+        test4_id,
+        test4_user
+    );
+    setup_dummy_ini(
+        github_token.as_deref(), // Token still comes from INI for this test
+        None,
+        Some(test4_user),
+    )
+    .await;
+    match upload_gist(
+        "UpdateTest",
+        "update_test.txt".to_string(), // Assuming this file exists in the gist
+        "Updated content using token from INI file.".to_string(),
+        true,
+    )
+    .await
+    {
+        Ok(_) => println!("upload_gist (Test 4) succeeded."),
+        Err(e) => println!("upload_gist (Test 4) failed: {}", e),
+    }
+    // Test 4 will likely fail if the token/id/username are not valid and
+    // corresponding.
+
+    println!("\n--- Cleaning up --- ");
+    cleanup_dummy_ini();
+    println!("--- Example finished ---");
+}

--- a/js/kv_bindings.js
+++ b/js/kv_bindings.js
@@ -426,6 +426,7 @@ async function wasm_fetch_with_request(url, options) {
 
         // Use the method from options or default to GET
         const method = options && options.method ? options.method : 'GET';
+        const body = options && options.body ? options.body : undefined;
 
         // Use either global fetch (Node.js 18+) or require node-fetch
         let fetchFunc = fetch;
@@ -442,6 +443,7 @@ async function wasm_fetch_with_request(url, options) {
         const response = await fetchFunc(url, {
             method,
             headers,
+            body,
             // Add other options as needed
         });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod parser;
 pub mod rulesets;
 pub mod settings;
 pub mod template;
+pub mod upload;
 pub mod utils;
 #[cfg(target_arch = "wasm32")]
 pub mod vfs;

--- a/src/upload/gist.rs
+++ b/src/upload/gist.rs
@@ -1,0 +1,227 @@
+use crate::settings::Settings;
+use crate::utils::file::file_exists;
+use crate::utils::http::{parse_proxy, ProxyConfig};
+use crate::utils::http_std::{web_patch_async, web_post_async, HttpError, HttpResponse};
+use crate::utils::ini_reader::{IniReader, IniReaderError};
+use case_insensitive_string::CaseInsensitiveString;
+use serde_json::json;
+use std::collections::HashMap;
+use std::env;
+
+/// Builds the JSON payload for creating or updating a Gist.
+fn build_gist_data(name: &str, content: &str) -> String {
+    json!({
+        "description": "subconverter",
+        "public": false,
+        "files": {
+            name: {
+                "content": content
+            }
+        }
+    })
+    .to_string()
+}
+
+/// Uploads content to a GitHub Gist based on configuration in gistconf.ini.
+///
+/// # Arguments
+/// * `name` - The logical name of the content (used for looking up path in
+///   ini).
+/// * `path` - The desired filename within the Gist. If empty, defaults to
+///   `name` or value from ini.
+/// * `content` - The content to upload.
+/// * `write_manage_url` - Whether to prepend a #!MANAGED-CONFIG line if
+///   updating an existing Gist.
+///
+/// # Returns
+/// * `Ok(())` on success.
+/// * `Err(String)` on failure, containing an error message.
+pub async fn upload_gist(
+    name: &str,
+    mut path: String,
+    mut content: String,
+    write_manage_url: bool,
+) -> Result<(), String> {
+    let ini_path = "gistconf.ini";
+
+    if !file_exists(ini_path).await {
+        log::error!("gistconf.ini not found. Skipping...");
+        return Err("gistconf.ini not found".to_string());
+    }
+
+    let mut ini = IniReader::new();
+    if let Err(e) = ini.parse_file(ini_path) {
+        let err_msg = format!("Failed to parse gistconf.ini: {}", e);
+        log::error!("{}", err_msg);
+        return Err(err_msg);
+    }
+
+    if ini.enter_section("common").is_err() {
+        log::error!("gistconf.ini has incorrect format ([common] section missing). Skipping...");
+        return Err("gistconf.ini has incorrect format".to_string());
+    }
+
+    let mut token = ini.get_current("token");
+    if token.is_empty() {
+        log::info!(
+            "Token not found in gistconf.ini, checking GITHUB_TOKEN environment variable..."
+        );
+        match env::var("GITHUB_TOKEN") {
+            Ok(env_token) if !env_token.is_empty() => {
+                token = env_token;
+            }
+            _ => {
+                log::error!(
+                    "No token provided in gistconf.ini or GITHUB_TOKEN environment variable. Skipping..."
+                );
+                return Err("No token provided".to_string());
+            }
+        }
+    }
+
+    let mut id = ini.get_current("id");
+    let mut username = ini.get_current("username");
+
+    if path.is_empty() {
+        let path_from_common = ini.get_current(name);
+        if !path_from_common.is_empty() {
+            path = path_from_common;
+        } else {
+            path = name.to_string();
+        }
+    }
+
+    let proxy_config = parse_proxy(&Settings::current().proxy_config);
+    let mut headers = HashMap::new();
+    headers.insert(
+        CaseInsensitiveString::new("Authorization"),
+        format!("token {}", token),
+    );
+    headers.insert(
+        CaseInsensitiveString::new("Accept"),
+        "application/vnd.github.v3+json".to_string(),
+    );
+    headers.insert(
+        CaseInsensitiveString::new("User-Agent"),
+        "subconverter-rs".to_string(),
+    ); // Good practice
+
+    let mut final_url = String::new(); // To store the raw URL after creation/update
+    let response: HttpResponse;
+
+    if id.is_empty() {
+        log::info!("No Gist id is provided. Creating new Gist...");
+        let gist_data = build_gist_data(&path, &content);
+        let api_url = "https://api.github.com/gists";
+
+        match web_post_async(api_url, gist_data, &proxy_config, Some(&headers)).await {
+            Ok(resp) => {
+                response = resp;
+                if response.status != 201 {
+                    let err_msg = format!(
+                        "Create new Gist failed!\nReturn code: {}\nReturn data:\n{}",
+                        response.status, response.body
+                    );
+                    log::error!("{}", err_msg);
+                    return Err("Failed to create Gist".to_string());
+                }
+            }
+            Err(e) => {
+                let err_msg = format!("Create new Gist HTTP request failed: {}", e);
+                log::error!("{}", err_msg);
+                return Err(err_msg);
+            }
+        }
+    } else {
+        log::info!("Gist id provided. Modifying Gist...");
+        let base_url = format!(
+            "https://gist.githubusercontent.com/{}/{}/raw/{}",
+            username, id, path
+        );
+
+        if write_manage_url {
+            content = format!("#!MANAGED-CONFIG {}\n{}", base_url, content);
+        }
+
+        let gist_data = build_gist_data(&path, &content);
+        let api_url = format!("https://api.github.com/gists/{}", id);
+
+        match web_patch_async(&api_url, gist_data, &proxy_config, Some(&headers)).await {
+            Ok(resp) => {
+                response = resp;
+                if response.status != 200 {
+                    let err_msg = format!(
+                        "Modify Gist failed!\nReturn code: {}\nReturn data:\n{}",
+                        response.status, response.body
+                    );
+                    log::error!("{}", err_msg);
+                    return Err("Failed to modify Gist".to_string());
+                }
+            }
+            Err(e) => {
+                let err_msg = format!("Modify Gist HTTP request failed: {}", e);
+                log::error!("{}", err_msg);
+                return Err(err_msg);
+            }
+        }
+    }
+
+    // Parse response JSON
+    match serde_json::from_str::<serde_json::Value>(&response.body) {
+        Ok(json) => {
+            if let Some(new_id) = json["id"].as_str() {
+                id = new_id.to_string();
+            }
+            if let Some(owner_login) = json["owner"]["login"].as_str() {
+                username = owner_login.to_string();
+            }
+
+            final_url = format!(
+                "https://gist.githubusercontent.com/{}/{}/raw/{}",
+                username, id, path
+            );
+
+            let log_msg = format!(
+                "Writing to Gist success!\nGenerator: {}\nPath: {}\nRaw URL: {}\nGist owner: {}",
+                name, path, final_url, username
+            );
+            log::info!("{}", log_msg);
+        }
+        Err(e) => {
+            let err_msg = format!(
+                "Failed to parse Gist API response JSON: {}\nResponse body:\n{}",
+                e, response.body
+            );
+            log::error!("{}", err_msg);
+            // Continue to save ini even if parsing fails, as the operation
+            // might have succeeded
+        }
+    }
+
+    // Update gistconf.ini
+    // Re-enter common section as it was left via get_current before
+    if ini.enter_section("common").is_ok() {
+        ini.erase_section(); // Erase the items within the section
+        ini.set_current("token", &token).ok(); // Pass as slice
+        ini.set_current("id", &id).ok(); // Pass as slice
+        ini.set_current("username", &username).ok(); // Pass as slice
+    } else {
+        // This shouldn't happen if the initial enter_section worked, but handle
+        // defensively
+        log::error!("Failed to re-enter [common] section to update ini.");
+    }
+
+    // Set the new section based on the actual path used
+    ini.set_current_section(&path);
+    ini.erase_section(); // Erase items in the path-named section
+    ini.set_current("type", name).ok();
+    ini.set_current("url", &final_url).ok();
+
+    if let Err(e) = ini.to_file(ini_path) {
+        let err_msg = format!("Failed to write updated gistconf.ini: {}", e);
+        log::error!("{}", err_msg);
+        return Err(err_msg);
+    }
+
+    Ok(())
+}

--- a/src/upload/gist.rs
+++ b/src/upload/gist.rs
@@ -34,14 +34,14 @@ fn build_gist_data(name: &str, content: &str) -> String {
 ///   updating an existing Gist.
 ///
 /// # Returns
-/// * `Ok(())` on success.
+/// * `Ok(String)` on success, containing the Gist raw URL.
 /// * `Err(String)` on failure, containing an error message.
 pub async fn upload_gist(
     name: &str,
     mut path: String,
     mut content: String,
     write_manage_url: bool,
-) -> Result<(), String> {
+) -> Result<String, String> {
     let ini_path = "gistconf.ini";
 
     if !file_exists(ini_path).await {
@@ -50,7 +50,7 @@ pub async fn upload_gist(
     }
 
     let mut ini = IniReader::new();
-    if let Err(e) = ini.parse_file(ini_path) {
+    if let Err(e) = ini.parse_file(ini_path).await {
         let err_msg = format!("Failed to parse gistconf.ini: {}", e);
         log::error!("{}", err_msg);
         return Err(err_msg);
@@ -223,5 +223,5 @@ pub async fn upload_gist(
         return Err(err_msg);
     }
 
-    Ok(())
+    Ok(final_url)
 }

--- a/src/upload/gist.rs
+++ b/src/upload/gist.rs
@@ -1,7 +1,7 @@
 use crate::settings::Settings;
 use crate::utils::file::file_exists;
-use crate::utils::http::{parse_proxy, ProxyConfig};
-use crate::utils::http_std::{web_patch_async, web_post_async, HttpError, HttpResponse};
+use crate::utils::http::{parse_proxy, HttpResponse, ProxyConfig};
+use crate::utils::http::{web_patch_async, web_post_async};
 use crate::utils::ini_reader::{IniReader, IniReaderError};
 use case_insensitive_string::CaseInsensitiveString;
 use serde_json::json;

--- a/src/upload/mod.rs
+++ b/src/upload/mod.rs
@@ -1,0 +1,1 @@
+pub mod gist;

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -4,16 +4,12 @@ use crate::utils::http::{parse_proxy, web_get_async};
 // Import platform-specific implementations
 #[cfg(not(target_arch = "wasm32"))]
 mod platform {
-    pub use crate::utils::file_std::{
-        copy_file, file_exists, file_get, file_get_async, read_file_async,
-    };
+    pub use crate::utils::file_std::{copy_file, file_exists, file_get_async, read_file_async};
 }
 
 #[cfg(target_arch = "wasm32")]
 mod platform {
-    pub use crate::utils::file_wasm::{
-        copy_file, file_exists, file_get, file_get_async, read_file_async,
-    };
+    pub use crate::utils::file_wasm::{copy_file, file_exists, file_get_async, read_file_async};
 }
 
 // Re-export platform-specific implementations

--- a/src/utils/file.rs
+++ b/src/utils/file.rs
@@ -4,12 +4,16 @@ use crate::utils::http::{parse_proxy, web_get_async};
 // Import platform-specific implementations
 #[cfg(not(target_arch = "wasm32"))]
 mod platform {
-    pub use crate::utils::file_std::*;
+    pub use crate::utils::file_std::{
+        copy_file, file_exists, file_get, file_get_async, read_file_async,
+    };
 }
 
 #[cfg(target_arch = "wasm32")]
 mod platform {
-    pub use crate::utils::file_wasm::*;
+    pub use crate::utils::file_wasm::{
+        copy_file, file_exists, file_get, file_get_async, read_file_async,
+    };
 }
 
 // Re-export platform-specific implementations

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -4,12 +4,18 @@ use std::collections::HashMap;
 // Import platform-specific implementations
 #[cfg(not(target_arch = "wasm32"))]
 mod platform {
-    pub use crate::utils::http_std::*;
+    pub use crate::utils::http_std::{
+        get_sub_info_from_header, get_sub_info_from_response, parse_proxy, web_get, web_get_async,
+        ProxyConfig,
+    };
 }
 
 #[cfg(target_arch = "wasm32")]
 mod platform {
-    pub use crate::utils::http_wasm::*;
+    pub use crate::utils::http_wasm::{
+        get_sub_info_from_header, get_sub_info_from_response, parse_proxy, web_get, web_get_async,
+        ProxyConfig,
+    };
 }
 
 // Re-export platform-specific implementations
@@ -17,7 +23,8 @@ pub use platform::*;
 
 /// Asynchronous function that returns only the body content if status is 2xx,
 /// otherwise treats as error
-/// This provides backward compatibility with code expecting only successful responses
+/// This provides backward compatibility with code expecting only successful
+/// responses
 pub async fn web_get_content_async(
     url: &str,
     proxy_config: &ProxyConfig,

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 mod platform {
     pub use crate::utils::http_std::{
         get_sub_info_from_header, get_sub_info_from_response, parse_proxy, web_get, web_get_async,
-        ProxyConfig,
+        web_patch_async, web_post_async, HttpError, HttpResponse, ProxyConfig,
     };
 }
 
@@ -14,7 +14,7 @@ mod platform {
 mod platform {
     pub use crate::utils::http_wasm::{
         get_sub_info_from_header, get_sub_info_from_response, parse_proxy, web_get, web_get_async,
-        ProxyConfig,
+        web_patch_async, web_post_async, HttpError, HttpResponse, ProxyConfig,
     };
 }
 

--- a/src/utils/http_wasm.rs
+++ b/src/utils/http_wasm.rs
@@ -347,7 +347,8 @@ pub async fn web_get_async(
     }
 }
 
-/// Synchronous version of web_get_async that uses tokio runtime to run the async function
+/// Synchronous version of web_get_async that uses tokio runtime to run the
+/// async function
 ///
 /// This function is provided for compatibility with the existing codebase.
 pub fn web_get(
@@ -365,7 +366,8 @@ pub fn web_get(
 
 /// Asynchronous function that returns only the body content if status is 2xx,
 /// otherwise treats as error
-/// This provides backward compatibility with code expecting only successful responses
+/// This provides backward compatibility with code expecting only successful
+/// responses
 pub async fn web_get_content_async(
     url: &str,
     proxy_config: &ProxyConfig,
@@ -466,5 +468,419 @@ pub fn get_sub_info_from_response(
         true
     } else {
         false
+    }
+}
+
+/// Makes an HTTP POST request to the specified URL (WASM environment)
+///
+/// # Arguments
+/// * `url` - The URL to request
+/// * `data` - The request body data
+/// * `_proxy_config` - Proxy configuration (ignored in WASM)
+/// * `headers` - Optional custom headers
+///
+/// # Returns
+/// * `Ok(HttpResponse)` - The response with status, body, and headers
+/// * `Err(HttpError)` - Error details if the request failed
+pub async fn web_post_async(
+    url: &str,
+    data: String,
+    _proxy_config: &ProxyConfig,
+    headers: Option<&HashMap<CaseInsensitiveString, String>>,
+) -> Result<HttpResponse, HttpError> {
+    let mut opts = RequestInit::new();
+    opts.set_method("POST");
+    opts.set_mode(RequestMode::Cors);
+    opts.set_body(Some(&JsValue::from_str(&data)));
+
+    // Create headers object
+    let request_headers = web_sys::Headers::new().map_err(|e| HttpError {
+        message: format!("Failed to create headers: {:?}", e),
+        status: None,
+    })?;
+    request_headers
+        .set("Content-Type", "application/json")
+        .map_err(|e| HttpError {
+            message: format!("Failed to set Content-Type header: {:?}", e),
+            status: None,
+        })?;
+
+    // Add custom headers
+    if let Some(custom_headers) = headers {
+        for (key, value) in custom_headers {
+            request_headers
+                .set(key.to_string().as_str(), value)
+                .map_err(|e| HttpError {
+                    message: format!("Failed to set header {}: {:?}", key, e),
+                    status: None,
+                })?;
+        }
+    }
+    opts.set_headers(Some(&request_headers));
+
+    // Try getting window object to determine environment
+    let window_available = web_sys::window().is_some();
+
+    if window_available {
+        // Browser environment
+        let request = Request::new_with_str_and_init(url, &opts).map_err(|e| HttpError {
+            message: format!("Failed to create POST request: {:?}", e),
+            status: None,
+        })?;
+
+        let window = web_sys::window().unwrap();
+        let resp_promise = window.fetch_with_request(&request);
+        let resp_value = JsFuture::from(resp_promise).await.map_err(|e| HttpError {
+            message: format!("Failed to get POST response: {:?}", e),
+            status: None,
+        })?;
+
+        let response: Response = resp_value.dyn_into().map_err(|_| HttpError {
+            message: "Failed to convert POST response".to_string(),
+            status: None,
+        })?;
+
+        let status = response.status();
+
+        // Get response headers
+        let mut resp_headers = HashMap::new();
+        let headers = response.headers();
+        let js_headers: Object = headers.into();
+        let entries = Object::entries(&js_headers);
+        let entries_array: Array = entries.into();
+        for i in 0..entries_array.length() {
+            let entry = entries_array.get(i);
+            let entry_array: Array = entry.into();
+            let key = entry_array.get(0);
+            let value = entry_array.get(1);
+            if let (Some(key_str), Some(value_str)) = (key.as_string(), value.as_string()) {
+                resp_headers.insert(key_str, value_str);
+            }
+        }
+
+        let text_promise = response.text().map_err(|e| HttpError {
+            message: format!("Failed to get POST response text: {:?}", e),
+            status: Some(status),
+        })?;
+
+        let text_value = JsFuture::from(text_promise).await.map_err(|e| HttpError {
+            message: format!("Failed to read POST response body: {:?}", e),
+            status: Some(status),
+        })?;
+
+        let body = text_value.as_string().ok_or_else(|| HttpError {
+            message: "Failed to convert POST response to string".to_string(),
+            status: Some(status),
+        })?;
+
+        Ok(HttpResponse {
+            status,
+            body,
+            headers: resp_headers,
+        })
+    } else {
+        // Node.js environment - use JS bindings
+        let request_options = Object::new();
+        js_sys::Reflect::set(
+            &request_options,
+            &JsValue::from_str("method"),
+            &JsValue::from_str("POST"),
+        )
+        .unwrap();
+        js_sys::Reflect::set(
+            &request_options,
+            &JsValue::from_str("body"),
+            &JsValue::from_str(&data),
+        )
+        .unwrap();
+
+        let headers_obj = Object::new();
+        js_sys::Reflect::set(
+            &headers_obj,
+            &JsValue::from_str("Content-Type"),
+            &JsValue::from_str("application/json"),
+        )
+        .unwrap();
+        if let Some(custom_headers) = headers {
+            for (key, value) in custom_headers {
+                js_sys::Reflect::set(
+                    &headers_obj,
+                    &JsValue::from_str(key.to_string().as_str()),
+                    &JsValue::from_str(value),
+                )
+                .unwrap();
+            }
+        }
+        js_sys::Reflect::set(
+            &request_options,
+            &JsValue::from_str("headers"),
+            &headers_obj,
+        )
+        .unwrap();
+
+        let resp_promise = js_wasm_fetch_with_request(url, &request_options);
+        let resp_value = JsFuture::from(resp_promise).await.map_err(|e| HttpError {
+            message: format!("Failed to get POST response: {:?}", e),
+            status: None,
+        })?;
+
+        let status_promise = js_response_status(&resp_value);
+        let status_value = JsFuture::from(status_promise)
+            .await
+            .map_err(|e| HttpError {
+                message: format!("Failed to get POST response status: {:?}", e),
+                status: None,
+            })?;
+        let status = status_value
+            .as_f64()
+            .map(|s| s as u16)
+            .ok_or_else(|| HttpError {
+                message: "Failed to convert POST status to number".to_string(),
+                status: None,
+            })?;
+
+        let headers_promise = js_response_headers(&resp_value);
+        let headers_value = JsFuture::from(headers_promise)
+            .await
+            .map_err(|e| HttpError {
+                message: format!("Failed to get POST response headers: {:?}", e),
+                status: Some(status),
+            })?;
+        let mut resp_headers = HashMap::new();
+        let headers_obj: Object = headers_value.dyn_into().unwrap_or_else(|_| Object::new());
+        let entries = Object::entries(&headers_obj);
+        let entries_array: Array = entries.into();
+        for i in 0..entries_array.length() {
+            let entry = entries_array.get(i);
+            let entry_array: Array = entry.into();
+            let key = entry_array.get(0);
+            let value = entry_array.get(1);
+            if let (Some(key_str), Some(value_str)) = (key.as_string(), value.as_string()) {
+                resp_headers.insert(key_str, value_str);
+            }
+        }
+
+        let text_promise = js_response_text(&resp_value);
+        let text_value = JsFuture::from(text_promise).await.map_err(|e| HttpError {
+            message: format!("Failed to read POST response body: {:?}", e),
+            status: Some(status),
+        })?;
+        let body = text_value.as_string().ok_or_else(|| HttpError {
+            message: "Failed to convert POST response to string".to_string(),
+            status: Some(status),
+        })?;
+
+        Ok(HttpResponse {
+            status,
+            body,
+            headers: resp_headers,
+        })
+    }
+}
+
+/// Makes an HTTP PATCH request to the specified URL (WASM environment)
+///
+/// # Arguments
+/// * `url` - The URL to request
+/// * `data` - The request body data
+/// * `_proxy_config` - Proxy configuration (ignored in WASM)
+/// * `headers` - Optional custom headers
+///
+/// # Returns
+/// * `Ok(HttpResponse)` - The response with status, body, and headers
+/// * `Err(HttpError)` - Error details if the request failed
+pub async fn web_patch_async(
+    url: &str,
+    data: String,
+    _proxy_config: &ProxyConfig,
+    headers: Option<&HashMap<CaseInsensitiveString, String>>,
+) -> Result<HttpResponse, HttpError> {
+    let mut opts = RequestInit::new();
+    opts.set_method("PATCH");
+    opts.set_mode(RequestMode::Cors);
+    opts.set_body(Some(&JsValue::from_str(&data)));
+
+    // Create headers object
+    let request_headers = web_sys::Headers::new().map_err(|e| HttpError {
+        message: format!("Failed to create headers: {:?}", e),
+        status: None,
+    })?;
+    request_headers
+        .set("Content-Type", "application/json")
+        .map_err(|e| HttpError {
+            message: format!("Failed to set Content-Type header: {:?}", e),
+            status: None,
+        })?;
+
+    // Add custom headers
+    if let Some(custom_headers) = headers {
+        for (key, value) in custom_headers {
+            request_headers
+                .set(key.to_string().as_str(), value)
+                .map_err(|e| HttpError {
+                    message: format!("Failed to set header {}: {:?}", key, e),
+                    status: None,
+                })?;
+        }
+    }
+    opts.set_headers(Some(&request_headers));
+
+    // Try getting window object to determine environment
+    let window_available = web_sys::window().is_some();
+
+    if window_available {
+        // Browser environment
+        let request = Request::new_with_str_and_init(url, &opts).map_err(|e| HttpError {
+            message: format!("Failed to create PATCH request: {:?}", e),
+            status: None,
+        })?;
+
+        let window = web_sys::window().unwrap();
+        let resp_promise = window.fetch_with_request(&request);
+        let resp_value = JsFuture::from(resp_promise).await.map_err(|e| HttpError {
+            message: format!("Failed to get PATCH response: {:?}", e),
+            status: None,
+        })?;
+
+        let response: Response = resp_value.dyn_into().map_err(|_| HttpError {
+            message: "Failed to convert PATCH response".to_string(),
+            status: None,
+        })?;
+
+        let status = response.status();
+
+        // Get response headers
+        let mut resp_headers = HashMap::new();
+        let headers = response.headers();
+        let js_headers: Object = headers.into();
+        let entries = Object::entries(&js_headers);
+        let entries_array: Array = entries.into();
+        for i in 0..entries_array.length() {
+            let entry = entries_array.get(i);
+            let entry_array: Array = entry.into();
+            let key = entry_array.get(0);
+            let value = entry_array.get(1);
+            if let (Some(key_str), Some(value_str)) = (key.as_string(), value.as_string()) {
+                resp_headers.insert(key_str, value_str);
+            }
+        }
+
+        let text_promise = response.text().map_err(|e| HttpError {
+            message: format!("Failed to get PATCH response text: {:?}", e),
+            status: Some(status),
+        })?;
+
+        let text_value = JsFuture::from(text_promise).await.map_err(|e| HttpError {
+            message: format!("Failed to read PATCH response body: {:?}", e),
+            status: Some(status),
+        })?;
+
+        let body = text_value.as_string().ok_or_else(|| HttpError {
+            message: "Failed to convert PATCH response to string".to_string(),
+            status: Some(status),
+        })?;
+
+        Ok(HttpResponse {
+            status,
+            body,
+            headers: resp_headers,
+        })
+    } else {
+        // Node.js environment - use JS bindings
+        let request_options = Object::new();
+        js_sys::Reflect::set(
+            &request_options,
+            &JsValue::from_str("method"),
+            &JsValue::from_str("PATCH"),
+        )
+        .unwrap();
+        js_sys::Reflect::set(
+            &request_options,
+            &JsValue::from_str("body"),
+            &JsValue::from_str(&data),
+        )
+        .unwrap();
+
+        let headers_obj = Object::new();
+        js_sys::Reflect::set(
+            &headers_obj,
+            &JsValue::from_str("Content-Type"),
+            &JsValue::from_str("application/json"),
+        )
+        .unwrap();
+        if let Some(custom_headers) = headers {
+            for (key, value) in custom_headers {
+                js_sys::Reflect::set(
+                    &headers_obj,
+                    &JsValue::from_str(key.to_string().as_str()),
+                    &JsValue::from_str(value),
+                )
+                .unwrap();
+            }
+        }
+        js_sys::Reflect::set(
+            &request_options,
+            &JsValue::from_str("headers"),
+            &headers_obj,
+        )
+        .unwrap();
+
+        let resp_promise = js_wasm_fetch_with_request(url, &request_options);
+        let resp_value = JsFuture::from(resp_promise).await.map_err(|e| HttpError {
+            message: format!("Failed to get PATCH response: {:?}", e),
+            status: None,
+        })?;
+
+        let status_promise = js_response_status(&resp_value);
+        let status_value = JsFuture::from(status_promise)
+            .await
+            .map_err(|e| HttpError {
+                message: format!("Failed to get PATCH response status: {:?}", e),
+                status: None,
+            })?;
+        let status = status_value
+            .as_f64()
+            .map(|s| s as u16)
+            .ok_or_else(|| HttpError {
+                message: "Failed to convert PATCH status to number".to_string(),
+                status: None,
+            })?;
+
+        let headers_promise = js_response_headers(&resp_value);
+        let headers_value = JsFuture::from(headers_promise)
+            .await
+            .map_err(|e| HttpError {
+                message: format!("Failed to get PATCH response headers: {:?}", e),
+                status: Some(status),
+            })?;
+        let mut resp_headers = HashMap::new();
+        let headers_obj: Object = headers_value.dyn_into().unwrap_or_else(|_| Object::new());
+        let entries = Object::entries(&headers_obj);
+        let entries_array: Array = entries.into();
+        for i in 0..entries_array.length() {
+            let entry = entries_array.get(i);
+            let entry_array: Array = entry.into();
+            let key = entry_array.get(0);
+            let value = entry_array.get(1);
+            if let (Some(key_str), Some(value_str)) = (key.as_string(), value.as_string()) {
+                resp_headers.insert(key_str, value_str);
+            }
+        }
+
+        let text_promise = js_response_text(&resp_value);
+        let text_value = JsFuture::from(text_promise).await.map_err(|e| HttpError {
+            message: format!("Failed to read PATCH response body: {:?}", e),
+            status: Some(status),
+        })?;
+        let body = text_value.as_string().ok_or_else(|| HttpError {
+            message: "Failed to convert PATCH response to string".to_string(),
+            status: Some(status),
+        })?;
+
+        Ok(HttpResponse {
+            status,
+            body,
+            headers: resp_headers,
+        })
     }
 }

--- a/src/utils/http_wasm.rs
+++ b/src/utils/http_wasm.rs
@@ -491,7 +491,7 @@ pub async fn web_post_async(
     let mut opts = RequestInit::new();
     opts.set_method("POST");
     opts.set_mode(RequestMode::Cors);
-    opts.set_body(Some(&JsValue::from_str(&data)));
+    opts.set_body(&JsValue::from_str(&data));
 
     // Create headers object
     let request_headers = web_sys::Headers::new().map_err(|e| HttpError {
@@ -516,7 +516,7 @@ pub async fn web_post_async(
                 })?;
         }
     }
-    opts.set_headers(Some(&request_headers));
+    opts.set_headers(&request_headers);
 
     // Try getting window object to determine environment
     let window_available = web_sys::window().is_some();
@@ -698,7 +698,7 @@ pub async fn web_patch_async(
     let mut opts = RequestInit::new();
     opts.set_method("PATCH");
     opts.set_mode(RequestMode::Cors);
-    opts.set_body(Some(&JsValue::from_str(&data)));
+    opts.set_body(&JsValue::from_str(&data));
 
     // Create headers object
     let request_headers = web_sys::Headers::new().map_err(|e| HttpError {
@@ -723,7 +723,7 @@ pub async fn web_patch_async(
                 })?;
         }
     }
-    opts.set_headers(Some(&request_headers));
+    opts.set_headers(&request_headers);
 
     // Try getting window object to determine environment
     let window_available = web_sys::window().is_some();

--- a/www/messages/en.json
+++ b/www/messages/en.json
@@ -203,6 +203,11 @@
             "addRule": "Add Rule",
             "match": "Match Pattern",
             "emoji": "Emoji"
+        },
+        "snippets": {
+            "title": "Snippets",
+            "emojiFileDesc": "Edit the default emoji rules file.",
+            "gistConfDesc": "Edit the Gist configuration file (if applicable)."
         }
     },
     "Common": {

--- a/www/messages/en.json
+++ b/www/messages/en.json
@@ -328,6 +328,10 @@
         "urlWillBeSaved": "This URL will be saved as a short link.",
         "shortUrlMessage": "A short URL has been created.",
         "conversionResultAriaLabel": "Conversion Result",
-        "downloadConfigButton": "Download Config"
+        "downloadConfigButton": "Download Config",
+        "uploadResultLabel": "Upload Result to Gist",
+        "uploadPathLabel": "Upload Gist Path",
+        "uploadPathPlaceholder": "e.g., profiles/my_config.yaml",
+        "uploadPathHelp": "Path on the server to save the converted result (requires server enablement)"
     }
 }

--- a/www/messages/zh.json
+++ b/www/messages/zh.json
@@ -331,6 +331,10 @@
         "urlWillBeSaved": "此URL将被保存为短链接。",
         "shortUrlMessage": "已创建短链接。",
         "conversionResultAriaLabel": "转换结果",
-        "downloadConfigButton": "下载配置"
+        "downloadConfigButton": "下载配置",
+        "uploadResultLabel": "上传结果到Gist",
+        "uploadPathLabel": "上传Gist路径",
+        "uploadPathPlaceholder": "例如：profiles/my_config.yaml",
+        "uploadPathHelp": "在服务器上保存转换结果的路径（需要服务器启用）"
     }
 }

--- a/www/messages/zh.json
+++ b/www/messages/zh.json
@@ -205,6 +205,11 @@
             "addRule": "添加规则",
             "match": "匹配模式",
             "emoji": "表情符号"
+        },
+        "snippets": {
+            "title": "代码片段",
+            "emojiFileDesc": "编辑默认的表情符号规则文件。",
+            "gistConfDesc": "编辑 Gist 配置文件（如果适用）。"
         }
     },
     "Common": {

--- a/www/package.json
+++ b/www/package.json
@@ -39,7 +39,7 @@
     "tailwindcss": "^4.1.4",
     "typescript": "^5.8.3",
     "url": "^0.11.4",
-    "subconverter-wasm": "0.2.27-beta.dev.17fbb5c"
+    "subconverter-wasm": "0.2.27-beta.dev.f9512e2"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/www/pnpm-lock.yaml
+++ b/www/pnpm-lock.yaml
@@ -48,8 +48,13 @@ importers:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
       subconverter-wasm:
+<<<<<<< HEAD
         specifier: 0.2.28
         version: 0.2.28
+=======
+        specifier: 0.2.27-beta.dev.f9512e2
+        version: 0.2.27-beta.dev.f9512e2
+>>>>>>> 40224c5 (Bump version to 0.2.27-beta.dev.f9512e2 for beta build)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.1
@@ -6425,7 +6430,11 @@ snapshots:
       client-only: 0.0.1
       react: 19.1.0
 
+<<<<<<< HEAD
   subconverter-wasm@0.2.28:
+=======
+  subconverter-wasm@0.2.27-beta.dev.f9512e2:
+>>>>>>> 40224c5 (Bump version to 0.2.27-beta.dev.f9512e2 for beta build)
     dependencies:
       '@netlify/blobs': 8.2.0
       '@vercel/kv': 3.0.0

--- a/www/src/app/convert/page.tsx
+++ b/www/src/app/convert/page.tsx
@@ -772,6 +772,32 @@ export default function ConvertPage() {
                                 className={getInputClass("token")}
                             />
                         </div>
+                        {/* Added Upload Fields */}
+                        <div className="flex items-center space-x-2">
+                            <input
+                                id="upload"
+                                name="upload"
+                                type="checkbox"
+                                checked={formData.upload}
+                                onChange={handleInputChange}
+                                className={checkboxClass}
+                            />
+                            <FieldLabel htmlFor="upload" fieldName="upload">{t('uploadResultLabel')}</FieldLabel>
+                        </div>
+                        <div>
+                            <FieldLabel htmlFor="upload_path" fieldName="upload_path">{t('uploadPathLabel')}</FieldLabel>
+                            <input
+                                type="text"
+                                id="upload_path"
+                                name="upload_path"
+                                value={formData.upload_path ?? ''}
+                                onChange={handleInputChange}
+                                className={getInputClass("upload_path")}
+                                disabled={!formData.upload}
+                                placeholder={t('uploadPathPlaceholder')}
+                            />
+                            <p className="mt-1 text-xs text-gray-500">{t('uploadPathHelp')}</p>
+                        </div>
                     </div>
                 </fieldset>
 

--- a/www/src/components/CodeEditor.tsx
+++ b/www/src/components/CodeEditor.tsx
@@ -7,21 +7,27 @@ import Editor, { Monaco } from '@monaco-editor/react';
 import { editor } from 'monaco-editor';
 
 interface CodeEditorProps {
-    filePath: string | null;
+    filePath?: string | null;
     language?: string;
     theme?: string;
+    value?: string;
+    readOnly?: boolean;
+    options?: editor.IStandaloneEditorConstructionOptions;
     onChange?: (value: string | undefined) => void;
-    onSave?: () => void;
+    onSave?: (filePath: string, content: string) => void;
 }
 
 export default function CodeEditor({
     filePath,
     language,
     theme = 'vs-dark',
+    value,
+    readOnly = false,
+    options,
     onChange,
     onSave
 }: CodeEditorProps) {
-    const [content, setContent] = useState<string>('');
+    const [internalContent, setInternalContent] = useState<string>('');
     const [editorLanguage, setEditorLanguage] = useState<string>(language || 'plaintext');
     const [loading, setLoading] = useState(false);
     const [saving, setSaving] = useState(false);
@@ -29,18 +35,26 @@ export default function CodeEditor({
     const [fileAttributes, setFileAttributes] = useState<FileAttributes | null>(null);
     const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
 
-    // Detect language from file extension
+    const isControlled = value !== undefined;
+    const displayContent = isControlled ? value : internalContent;
+
+    // Detect language from file extension if filePath is provided and language isn't
     useEffect(() => {
-        if (!filePath || language) return;
+        if (!filePath || language) {
+            setEditorLanguage(language || 'plaintext');
+            return;
+        }
 
         const extension = filePath.split('.').pop()?.toLowerCase();
         let detectedLanguage = 'plaintext';
 
         switch (extension) {
             case 'js':
+            case 'jsx':
                 detectedLanguage = 'javascript';
                 break;
             case 'ts':
+            case 'tsx':
                 detectedLanguage = 'typescript';
                 break;
             case 'json':
@@ -76,72 +90,76 @@ export default function CodeEditor({
         setEditorLanguage(detectedLanguage);
     }, [filePath, language]);
 
-    // Load file content when filePath changes
+    // Load file content only if not controlled and filePath changes
     useEffect(() => {
-        if (!filePath) {
-            setContent('');
-            setError(null);
+        if (isControlled || !filePath) {
+            // If controlled or no path, clear attributes and don't load
             setFileAttributes(null);
+            if (!isControlled) setInternalContent(''); // Clear internal if no path
+            setError(null);
             return;
         }
 
         const loadFile = async () => {
             setLoading(true);
             setError(null);
+            setFileAttributes(null);
             try {
                 // Get file content
                 const fileContent = await apiClient.readFile(filePath);
-                setContent(fileContent || '');
+                setInternalContent(fileContent || '');
 
                 // Get file attributes if available
                 try {
                     const attributes = await apiClient.getFileAttributes(filePath);
                     setFileAttributes(attributes);
                 } catch (attrError) {
-                    console.error('Error loading file attributes:', attrError);
-                    setFileAttributes(null);
-                    // Don't block file loading if attributes fail
-                }
+                    console.warn('Could not load file attributes:', attrError);
+                } // Non-critical error
             } catch (err) {
                 setError(err instanceof Error ? err.message : 'Failed to load file');
                 console.error('Error loading file:', err);
+                setInternalContent('# Error loading file');
             } finally {
                 setLoading(false);
             }
         };
 
         loadFile();
-    }, [filePath]);
+    }, [filePath, isControlled]); // Rerun if filePath changes or becomes controlled/uncontrolled
 
     // Handle editor mount
-    function handleEditorDidMount(editor: editor.IStandaloneCodeEditor, _monaco: Monaco) {
+    function handleEditorDidMount(editor: editor.IStandaloneCodeEditor, monaco: Monaco) {
         editorRef.current = editor;
 
-        // Add keyboard shortcut for saving (Ctrl+S)
-        editor.addCommand(
-            _monaco.KeyMod.CtrlCmd | _monaco.KeyCode.KeyS,
-            () => handleSave()
-        );
+        // Add keyboard shortcut for saving (Ctrl+S) only if not readOnly and filePath exists
+        if (!readOnly && filePath) {
+            editor.addCommand(
+                monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS,
+                () => handleSave()
+            );
+        }
     }
 
     // Save file content
     const handleSave = async () => {
-        if (!filePath) return;
+        if (!filePath || readOnly || isControlled) return; // Don't save if no path, readOnly, or controlled
 
         setSaving(true);
         setError(null);
         try {
-            await apiClient.writeFile(filePath, content);
+            const contentToSave = internalContent; // In uncontrolled mode, internal state is the source
+            await apiClient.writeFile(filePath, contentToSave);
 
             // Refresh file attributes after save
             try {
                 const attributes = await apiClient.getFileAttributes(filePath);
                 setFileAttributes(attributes);
             } catch (attrError) {
-                console.error('Error refreshing file attributes:', attrError);
+                console.warn('Could not refresh file attributes:', attrError);
             }
 
-            if (onSave) onSave();
+            if (onSave) onSave(filePath, contentToSave);
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Failed to save file');
             console.error('Error saving file:', err);
@@ -151,10 +169,30 @@ export default function CodeEditor({
     };
 
     // Handle content change
-    const handleEditorChange = (value: string | undefined) => {
-        setContent(value || '');
-        if (onChange) onChange(value);
+    const handleEditorChange = (newValue: string | undefined) => {
+        const currentVal = newValue || '';
+        if (!isControlled) {
+            setInternalContent(currentVal); // Update internal state if uncontrolled
+        }
+        if (onChange) {
+            onChange(currentVal); // Always call onChange for parent component
+        }
     };
+
+    const finalOptions: editor.IStandaloneEditorConstructionOptions = {
+        minimap: { enabled: true },
+        fontSize: 14,
+        wordWrap: 'on',
+        scrollBeyondLastLine: false,
+        automaticLayout: true,
+        tabSize: 2,
+        lineNumbers: 'on',
+        readOnly: readOnly, // Set readOnly status
+        ...options, // Merge with any additional options passed in
+    };
+
+    const showSaveButton = filePath && !readOnly && !isControlled;
+    const showFileInfo = fileAttributes && !readOnly; // Show file info only if not readOnly
 
     return (
         <div className="h-full flex flex-col">
@@ -162,17 +200,17 @@ export default function CodeEditor({
             <div className="flex justify-between items-center p-2 border-b border-gray-700">
                 <div className="flex items-center space-x-2 overflow-hidden">
                     <h3 className="text-sm font-semibold truncate text-gray-200">
-                        {filePath || 'No file selected'}
+                        {filePath || 'Unsaved Content'} {readOnly ? '(Read-only)' : ''}
                     </h3>
-                    {fileAttributes && (
+                    {showFileInfo && (
                         <div className="text-xs bg-gray-700 text-gray-200 px-2 py-0.5 rounded">
                             {apiClient.formatFileSize(fileAttributes.size)}
                         </div>
                     )}
                 </div>
-                {filePath && (
+                {showSaveButton && (
                     <button
-                        className={`px-3 py-1 rounded text-sm ${saving
+                        className={`px-3 py-1 rounded text-sm ${saving || loading
                             ? 'bg-gray-600 text-gray-300 cursor-not-allowed'
                             : 'bg-blue-600 hover:bg-blue-700 text-white'
                             }`}
@@ -186,7 +224,7 @@ export default function CodeEditor({
 
             {/* Editor area */}
             <div className="flex-grow relative">
-                {loading ? (
+                {(loading && !isControlled) ? (
                     <div className="absolute inset-0 flex items-center justify-center">
                         <div className="flex flex-col items-center">
                             <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-blue-500 mb-2"></div>
@@ -197,33 +235,25 @@ export default function CodeEditor({
                     <div className="absolute inset-0 flex items-center justify-center text-red-400 p-4 text-center bg-gray-800">
                         {error}
                     </div>
-                ) : !filePath ? (
+                ) : (!filePath && !isControlled) ? (
                     <div className="absolute inset-0 flex items-center justify-center text-gray-300 p-4 text-center">
-                        Select a file to edit
+                        Select a file or provide content
                     </div>
                 ) : (
                     <Editor
                         height="100%"
                         language={editorLanguage}
                         theme={theme}
-                        value={content}
+                        value={displayContent}
                         onChange={handleEditorChange}
                         onMount={handleEditorDidMount}
-                        options={{
-                            minimap: { enabled: true },
-                            fontSize: 14,
-                            wordWrap: 'on',
-                            scrollBeyondLastLine: false,
-                            automaticLayout: true,
-                            tabSize: 2,
-                            lineNumbers: 'on',
-                        }}
+                        options={finalOptions}
                     />
                 )}
             </div>
 
             {/* File info footer */}
-            {fileAttributes && (
+            {showFileInfo && (
                 <div className="border-t border-gray-700 px-2 py-1 text-xs text-gray-300 flex justify-between">
                     <div>Type: {fileAttributes.file_type || 'Unknown'}</div>
                     <div>


### PR DESCRIPTION
- Introduced a new module for uploading content to GitHub Gists, including the `upload_gist` function.
- Added an example for uploading a Gist, demonstrating the use of the new functionality.
- Updated `Cargo.toml` to include `tokio-macros` feature for the Tokio dependency.
- Modified the `subconverter` function to support Gist uploads based on configuration.
- Enhanced HTTP utility functions for making asynchronous POST and PATCH requests.
- Updated `Cargo.lock` to reflect new dependencies and versions.
- Consolidated HTTP utility imports in `gist.rs` and `http.rs` for clarity.
- Updated request option settings in `http_wasm.rs` to remove unnecessary `Some` wrappers around headers and body.
- Enhanced code readability by aligning import statements and reducing redundancy.
- Added a new `upload_status` field to the `SubResponse` struct to track Gist upload attempts.
- Updated the `upload_gist` function to return the Gist URL upon successful upload.
- Introduced a `snippets` section in the settings page for editing `emoji.txt` and `gistconf.ini` files directly.
- Enhanced the `CodeEditor` component to support read-only mode and improved file handling.
- Updated language files to include descriptions for the new snippets section.