### PR TITLE
Update VmessProxy struct to clarify alterId requirement

### DIFF
--- a/src/generator/yaml/clash/output_proxy_types/clash_output_vmess.rs
+++ b/src/generator/yaml/clash/output_proxy_types/clash_output_vmess.rs
@@ -12,7 +12,8 @@ pub struct VmessProxy {
     pub common: CommonProxyOptions,
     #[serde(skip_serializing_if = "is_empty_option_string")]
     pub uuid: Option<String>,
-    /// This is required
+    /// This is required by Clash, and the name is `alterId`
+    #[serde(rename = "alterId")]
     pub alter_id: u32,
     #[serde(skip_serializing_if = "is_empty_option_string")]
     pub cipher: Option<String>,


### PR DESCRIPTION
- Added a comment to specify that `alterId` is required by Clash.
- Renamed the `alter_id` field to `alterId` for consistency with Clash's naming convention.

The name of `alterId` is special in clash ...