### PR TITLE
Enhance JavaScript runtime support and build configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       run: cargo install cross
       
     - name: Build with cross
-      run: cross build --release --features=web-api --target ${{ matrix.target }}
+      run: cross build --release --features=web-api${{ matrix.arch == 'amd64' && ',js-runtime' || '' }} --target ${{ matrix.target }}
       
     - name: Prepare artifact
       run: |
@@ -162,7 +162,7 @@ jobs:
         echo "Updated Cargo.toml version for branch build to ${{ env.RELEASE_VERSION }}"
         
     - name: Build
-      run: cargo build --release --features=web-api --target ${{ matrix.target }}
+      run: cargo build --release --features=web-api,js-runtime --target ${{ matrix.target }}
       
     - name: Prepare artifact
       run: |
@@ -240,7 +240,7 @@ jobs:
     - name: Build
       run: |
         cargo install --force --locked bindgen-cli
-        cargo build --release --features=web-api --target ${{ matrix.target }}
+        cargo build --release --features=web-api${{ matrix.arch == 'amd64' && ',js-runtime' || '' }} --target ${{ matrix.target }}
       
     - name: Prepare artifact
       shell: bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = []
 web-api = ["actix-web"]
-
+js-runtime = ["rquickjs"]
 
 [[bin]]
 name = "subconverter"
@@ -67,7 +67,7 @@ web-sys = { version = "0.3", features = [
 console_log = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-rquickjs = "0.9.0"
+rquickjs = { version = "0.9.0", optional = true }
 awc = { version = "3.6.0", features = ["rustls"] }
 tokio = { version = "1.43.0", features = [
     "rt",

--- a/src/api/sub.rs
+++ b/src/api/sub.rs
@@ -234,10 +234,10 @@ pub async fn sub_process(
         None => global.update_interval,
     });
     // Check if we should authorize the request, if we are in API mode
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(feature = "js-runtime"))]
     let authorized = false;
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(feature = "js-runtime")]
     let authorized =
         !global.api_mode || query.token.as_deref().unwrap_or_default() == global.api_access_token;
     builder.authorized(authorized);

--- a/src/models/extra_settings.rs
+++ b/src/models/extra_settings.rs
@@ -55,10 +55,10 @@ pub struct ExtraSettings {
     /// Whether the export is authorized
     pub authorized: bool,
     /// JavaScript runtime context (not implemented in Rust version)
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "js-runtime")]
     pub js_context: Option<rquickjs::Context>,
     /// JavaScript runtime
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "js-runtime")]
     pub js_runtime: Option<rquickjs::Runtime>,
 }
 
@@ -130,15 +130,15 @@ impl Default for ExtraSettings {
                 global.clash_proxy_groups_style.clone()
             },
             authorized: false,
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(feature = "js-runtime")]
             js_context: None,
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(feature = "js-runtime")]
             js_runtime: None,
         }
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "js-runtime")]
 impl ExtraSettings {
     pub fn init_js_context(&mut self) {
         if self.js_runtime.is_none() {
@@ -376,7 +376,7 @@ impl ExtraSettings {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(not(feature = "js-runtime"))]
 impl ExtraSettings {
     pub fn init_js_context(&mut self) {}
     pub fn eval_filter_function(
@@ -384,26 +384,38 @@ impl ExtraSettings {
         _nodes: &mut Vec<Proxy>,
         _source_str: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        Err("JavaScript is not supported on WASM".into())
+        Err(
+            "JavaScript is not supported in this build, please enable js-runtime feature in cargo build"
+                .into(),
+        )
     }
     pub async fn eval_sort_nodes(
         &mut self,
         _nodes: &mut Vec<Proxy>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        Err("JavaScript is not supported on WASM".into())
+        Err(
+            "JavaScript is not supported in this build, please enable js-runtime feature in cargo build"
+                .into(),
+        )
     }
     pub async fn eval_get_rename_node_remark(
         &self,
         _node: &Proxy,
         _match_script: String,
     ) -> Result<String, Box<dyn std::error::Error>> {
-        Err("JavaScript is not supported on WASM".into())
+        Err(
+            "JavaScript is not supported in this build, please enable js-runtime feature in cargo build"
+                .into(),
+        )
     }
     pub async fn eval_get_emoji_node_remark(
         &self,
         _node: &Proxy,
         _match_script: String,
     ) -> Result<String, Box<dyn std::error::Error>> {
-        Err("JavaScript is not supported on WASM".into())
+        Err(
+            "JavaScript is not supported in this build, please enable js-runtime feature in cargo build"
+                .into(),
+        )
     }
 }

--- a/src/models/proxy.rs
+++ b/src/models/proxy.rs
@@ -198,9 +198,9 @@ impl Default for Proxy {
         }
     }
 }
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "js-runtime")]
 use rquickjs::{Ctx, IntoJs};
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "js-runtime")]
 impl<'js> IntoJs<'js> for Proxy {
     fn into_js(self, ctx: &Ctx<'js>) -> Result<rquickjs::Value<'js>, rquickjs::Error> {
         let value =


### PR DESCRIPTION
- Added a new feature flag `js-runtime` in `Cargo.toml` to conditionally include the `rquickjs` dependency.
- Updated build commands in GitHub Actions to include the `js-runtime` feature for the `amd64` architecture.
- Refactored authorization checks in the `sub_process` function and updated the `ExtraSettings` struct to conditionally include JavaScript context and runtime fields.
- Improved error handling in methods related to JavaScript execution, providing clearer messages when the feature is not enabled.